### PR TITLE
Bump DuckDB and Microsoft.Data.Sqlite.Core

### DIFF
--- a/DubUrl.OleDb.Testing/DubUrl.OleDb.Testing.csproj
+++ b/DubUrl.OleDb.Testing/DubUrl.OleDb.Testing.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Bindings" Version="0.8.0" />
-    <PackageReference Include="DuckDB.NET.Data" Version="0.8.0" />
+    <PackageReference Include="DuckDB.NET.Bindings" Version="0.8.1" />
+    <PackageReference Include="DuckDB.NET.Data" Version="0.8.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -59,11 +59,11 @@
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Dapper" Version="2.0.143" />
-    <PackageReference Include="DuckDB.NET.Bindings" Version="0.8.0" />
-    <PackageReference Include="DuckDB.NET.Data" Version="0.8.0" />
+    <PackageReference Include="DuckDB.NET.Bindings" Version="0.8.1" />
+    <PackageReference Include="DuckDB.NET.Data" Version="0.8.1" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="9.1.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.8" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="MySqlConnector" Version="2.2.6" />
     <PackageReference Include="Npgsql" Version="7.0.4" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
 		<PackageReference Include="Domemtech.StringTemplate4" Version="4.3.0" />
-		<PackageReference Include="DuckDB.NET.Bindings" Version="0.8.0" />
-		<PackageReference Include="DuckDB.NET.Data" Version="0.8.0" />
+		<PackageReference Include="DuckDB.NET.Bindings" Version="0.8.1" />
+		<PackageReference Include="DuckDB.NET.Data" Version="0.8.1" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
@@ -20,7 +20,7 @@
 	<ItemGroup>
 		<PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="9.1.1" />
 		<PackageReference Include="Net.IBM.Data.Db2" Version="7.0.0.200" />
-		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.8" />
+		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.9" />
 		<PackageReference Include="MySql.Data" Version="8.0.33" />
 		<PackageReference Include="MySqlConnector" Version="2.2.6" />
 		<PackageReference Include="Npgsql" Version="7.0.4" />


### PR DESCRIPTION
✅ This PR was created by the Combine PRs action by combining the following PRs:
#466 Bump DuckDB.NET.Data from 0.8.0 to 0.8.1 in /DubUrl.OleDb.Testing
#464 Bump DuckDB.NET.Data from 0.8.0 to 0.8.1 in /DubUrl.Testing
#462 Bump DuckDB.NET.Bindings from 0.8.0 to 0.8.1 in /DubUrl.QA
-----  Bump Microsoft.Data.Sqlite.Core from 7.0.8 to 7.0.9 in /DubUrl.QA
-----  Bump Microsoft.Data.Sqlite.Core from 7.0.8 to 7.0.9 in /DubUrl.Testing