### PR TITLE
revert: downgrade Npgsql from 8.0.0 to 7.0.6

### DIFF
--- a/.github/conventional_commits_labels.json
+++ b/.github/conventional_commits_labels.json
@@ -1,14 +1,14 @@
 {
-  "!": "breaking-change",
-  "chore": "dependency-update",
-  "docs": "docs",
-  "style": "none",
-  "ci": "build",
-  "build": "build",
-  "feat": "new-feature",
-  "test": "none",
-  "refactor": "none",
-  "revert": "none",
-  "perf": "enhancement",
-  "fix": "bug"
+    "!": "breaking-change",
+    "chore": "dependency-update",
+    "docs": "docs",
+    "style": "none",
+    "ci": "build",
+    "build": "build",
+    "feat": "new-feature",
+    "test": "none",
+    "refactor": "none",
+    "revert": "bug",
+    "perf": "enhancement",
+    "fix": "bug"
 }

--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -77,7 +77,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MySqlConnector" Version="2.3.1" />
-    <PackageReference Include="Npgsql" Version="8.0.0" />
+    <PackageReference Include="Npgsql" Version="7.0.6" />
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
     <PackageReference Include="MySql.Data" Version="8.2.0" />
     <PackageReference Include="MySqlConnector" Version="2.3.1" />
-    <PackageReference Include="Npgsql" Version="8.0.0" />
+    <PackageReference Include="Npgsql" Version="7.0.6" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.120" />
     <PackageReference Include="Snowflake.Data" Version="2.1.3" />
     <PackageReference Include="System.Data.Odbc" Version="8.0.0" />


### PR DESCRIPTION
reason: not supporting 'Integrated Security' keyword