### PR TITLE
chore: bump Microsoft.Identity.Client from 4.67.2 to 4.69.1

### DIFF
--- a/DubUrl.Adomd/DubUrl.Adomd.csproj
+++ b/DubUrl.Adomd/DubUrl.Adomd.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.84.1" />
     <PackageReference Include="System.Management" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.69.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated an authentication-related dependency to the latest version, ensuring improved stability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->