### PR TITLE
chore: bump Didot from 0.25.0 to 0.25.3

### DIFF
--- a/DubUrl.Schema/DubUrl.Schema.csproj
+++ b/DubUrl.Schema/DubUrl.Schema.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
 	  <EmbeddedResource Include="Renderers\Templates\DropTablesIfExists.sql.hbs" />
@@ -10,7 +10,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Didot.Core" Version="0.25.0" />
+	  <PackageReference Include="Didot.Core" Version="0.25.3" />
 	</ItemGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the `Didot.Core` package from version `0.25.0` to `0.25.3`.
  - Refined project configuration for improved stability.
  - These behind-the-scenes adjustments do not affect the app’s visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->