### PR TITLE
chore: bump Didot from 0.27.0 to 0.27.10

### DIFF
--- a/DubUrl.Schema/DubUrl.Schema.csproj
+++ b/DubUrl.Schema/DubUrl.Schema.csproj
@@ -10,7 +10,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Didot.Core" Version="0.27.0" />
+	  <PackageReference Include="Didot.Core" Version="0.27.10" />
 	</ItemGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Didot.Core package to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->