### PR TITLE
chore: bump Oracle.ManagedDataAccess.Core from 23.7.0 to 23.8.0

### DIFF
--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Domemtech.StringTemplate4" Version="4.3.0" />
     <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.2.1" />
@@ -9,7 +9,7 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.4" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.8.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />
     <PackageReference Include="Snowflake.Data" Version="4.3.0" />
     <PackageReference Include="Teradata.Client.Provider" Version="20.0.3" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Oracle database driver to the latest version for improved compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->