### PR TITLE
chore: bump System.Data.OleDb from 9.0.4 to 9.0.5

### DIFF
--- a/DubUrl.OleDb/DubUrl.OleDb.csproj
+++ b/DubUrl.OleDb/DubUrl.OleDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="System.Data.OleDb" Version="9.0.4" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -95,7 +95,7 @@
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
-    <PackageReference Include="System.Data.OleDb" Version="9.0.4" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.4" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Npgsql" Version="9.0.3" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Management" Version="9.0.5" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
-    <PackageReference Include="System.Data.OleDb" Version="9.0.4" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the System.Data.OleDb package to version 9.0.5 across multiple components to ensure consistency and up-to-date dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->