### PR TITLE
chore: bump Microsoft.Data.Sqlite.Core from 9.0.4 to 9.0.5

### DIFF
--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -90,7 +90,7 @@
     <PackageReference Include="DuckDB.NET.Data" Version="1.2.1" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.5" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.84.1" />
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.5" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.8.0" />
     <PackageReference Include="MySql.Data" Version="9.3.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Microsoft.Data.Sqlite.Core library to version 9.0.5 for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->