### PR TITLE
chore: bump Net.IBM.Data.Db2 from 9.0.0.100 to 9.0.0.200

### DIFF
--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Net.IBM.Data.Db2" Version="8.0.0.300" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Net.IBM.Data.Db2" Version="9.0.0.100" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PackageReference Include="Net.IBM.Data.Db2" Version="9.0.0.200" Condition="'$(TargetFramework)' != 'net8.0'" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="9.0.5" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the version of the Net.IBM.Data.Db2 package for improved compatibility on certain target frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->