### PR TITLE
feat: create indexes in a schema

### DIFF
--- a/DubUrl.Schema.Testing/Builders/IndexBuilderTests.cs
+++ b/DubUrl.Schema.Testing/Builders/IndexBuilderTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Builders;
+using DubUrl.Schema.Constraints;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace DubUrl.Schema.Testing.Builders;
+
+public class IndexBuilderTests
+{
+    [Test]
+    public void Build_Simple_Expected()
+    {
+        var builder = new IndexBuilder()
+                            .WithName("idx")
+                            .OnTable("table")
+                            .WithColumns(cols =>
+                                cols.Add(col => col.WithName("id"))
+                                .Add(col => col.WithName("name"))
+                            );
+        var index = builder.Build();
+        Assert.Multiple(() =>
+        {
+            Assert.That(index, Is.Not.Null);
+            Assert.That(index, Is.TypeOf<Index>());
+        });
+        Assert.Multiple(() =>
+        {
+            Assert.That(index.Name, Is.EqualTo("idx"));
+            Assert.That(index.TableName, Is.EqualTo("table"));
+            Assert.That(index.Columns, Has.Count.EqualTo(2));
+            Assert.That(index.Columns, Does.ContainKey("id"));
+            Assert.That(index.Columns, Does.ContainKey("name"));
+        });
+    }
+}

--- a/DubUrl.Schema.Testing/Builders/SchemaBuilderTests.cs
+++ b/DubUrl.Schema.Testing/Builders/SchemaBuilderTests.cs
@@ -32,4 +32,34 @@ public class SchemaBuilderTests
             Assert.That(schema.Tables, Has.Count.EqualTo(2));
         });
     }
+
+    [Test]
+    public void Build_SimpleWithIndex_Expected()
+    {
+        var builder = new SchemaBuilder()
+                            .WithTables(tables =>
+                                tables.Add(table => table.WithName("Customer")
+                                                        .WithColumns(cols => cols.Add(col => col.WithName("CustomerId").WithType(DbType.Int32))))
+                                    .Add(table => table.WithName("Sales")
+                                                        .WithColumns(cols => cols.Add(col => col.WithName("SalesId").WithType(DbType.Int64)))))
+                            .WithIndexes(indexes =>
+                                indexes.Add(index => index.WithName("IX_CustomerId")
+                                                          .OnTable("Customer")
+                                                          .WithColumns(cols => cols.Add(col => col.WithName("CustomerId"))))
+                                       .Add(index => index.WithName("IX_SalesId")
+                                                          .OnTable("Sales")
+                                                          .WithColumns(cols => cols.Add(col => col.WithName("SalesId"))))
+                            );
+        var schema = builder.Build();
+        Assert.Multiple(() =>
+        {
+            Assert.That(schema, Is.Not.Null);
+            Assert.That(schema, Is.TypeOf<Schema>());
+        });
+        Assert.Multiple(() =>
+        {
+            Assert.That(schema.Tables, Has.Count.EqualTo(2));
+            Assert.That(schema.Indexes, Has.Count.EqualTo(2));
+        });
+    }
 }

--- a/DubUrl.Schema/Builders/IndexBuilder.Interfaces.cs
+++ b/DubUrl.Schema/Builders/IndexBuilder.Interfaces.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DubUrl.Schema.Builders;
+
+public interface IIndexTableBuilder
+{
+    IIndexColumnCollectionBuilder OnTable(string name);
+}
+
+public interface IIndexColumnCollectionBuilder
+{
+    IIndexBuilder WithColumns(Func<IndexColumnCollectionBuilder, IndexColumnCollectionBuilder> columns);
+}
+
+public interface IIndexBuilder
+{
+    Index Build();
+}

--- a/DubUrl.Schema/Builders/IndexBuilder.cs
+++ b/DubUrl.Schema/Builders/IndexBuilder.cs
@@ -12,7 +12,6 @@ public class IndexBuilder : IIndexTableBuilder, IIndexColumnCollectionBuilder, I
     private string? Name { get; set; }
     private string? TableName { get; set; }
     private IndexColumnCollectionBuilder Columns { get; set; } = [];
-    private Table? Table { get; set; }
 
     public IIndexTableBuilder WithName(string name)
     {

--- a/DubUrl.Schema/Builders/IndexBuilder.cs
+++ b/DubUrl.Schema/Builders/IndexBuilder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema.Builders;
+
+public class IndexBuilder : IIndexTableBuilder, IIndexColumnCollectionBuilder, IIndexBuilder
+{
+    private string? Name { get; set; }
+    private string? TableName { get; set; }
+    private IndexColumnCollectionBuilder Columns { get; set; } = [];
+    private Table? Table { get; set; }
+
+    public IIndexTableBuilder WithName(string name)
+    {
+        Name = name;
+        return this;
+    }
+
+    public IIndexColumnCollectionBuilder OnTable(string name)
+    {
+        TableName = name;
+        return this;
+    }
+
+    public IIndexBuilder WithColumns(Func<IndexColumnCollectionBuilder, IndexColumnCollectionBuilder> columns)
+    {
+        Columns = columns(Columns);
+        return this;
+    }
+
+    public Index Build()
+    {
+        if (Name is null)
+            throw new ArgumentNullException(nameof(Name));
+        if (TableName is null)
+            throw new ArgumentNullException(nameof(TableName));
+        var columns = Columns.Select(c => c.Build()).ToArray();
+
+        if (columns.GroupBy(c => c.Name).Count() != columns.Length)
+            throw new InvalidOperationException("Column names must be unique.");
+
+        return new Index(Name, TableName, columns);
+    }
+}

--- a/DubUrl.Schema/Builders/IndexCollectionBuilder.cs
+++ b/DubUrl.Schema/Builders/IndexCollectionBuilder.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace DubUrl.Schema.Builders;
 
 /// <summary>
-/// Adds a new table to the collection.
+/// Adds a new index to the collection.
 /// </summary>
 /// <param name="indexBuilder">A function that configures and returns an index builder.</param>
 /// <returns>This instance for method chaining.</returns>
@@ -16,10 +16,10 @@ public class IndexCollectionBuilder : IEnumerable<IIndexBuilder>
 {
     private List<IIndexBuilder> Indexs { get; } = [];
 
-    public IndexCollectionBuilder Add(Func<IndexBuilder, IIndexBuilder> table)
+    public IndexCollectionBuilder Add(Func<IndexBuilder, IIndexBuilder> index)
     {
-        ArgumentNullException.ThrowIfNull(table);
-        Indexs.Add(table(new()));
+        ArgumentNullException.ThrowIfNull(index);
+        Indexs.Add(index(new()));
         return this;
     }
 

--- a/DubUrl.Schema/Builders/IndexCollectionBuilder.cs
+++ b/DubUrl.Schema/Builders/IndexCollectionBuilder.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DubUrl.Schema.Builders;
+
+/// <summary>
+/// Adds a new table to the collection.
+/// </summary>
+/// <param name="indexBuilder">A function that configures and returns an index builder.</param>
+/// <returns>This instance for method chaining.</returns>
+public class IndexCollectionBuilder : IEnumerable<IIndexBuilder>
+{
+    private List<IIndexBuilder> Indexs { get; } = [];
+
+    public IndexCollectionBuilder Add(Func<IndexBuilder, IIndexBuilder> table)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        Indexs.Add(table(new()));
+        return this;
+    }
+
+    public void Add(IIndexBuilder item) => Indexs.Add(item);
+    public void Clear() => Indexs.Clear();
+    public bool Contains(IIndexBuilder item) => Indexs.Contains(item);
+    public void CopyTo(IIndexBuilder[] array, int arrayIndex) => Indexs.CopyTo(array, arrayIndex);
+    public bool Remove(IIndexBuilder item) => Indexs.Remove(item);
+
+    public IEnumerator<IIndexBuilder> GetEnumerator()
+        => Indexs.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()
+        => GetEnumerator();
+}

--- a/DubUrl.Schema/Builders/IndexColumnBuilder.Interfaces.cs
+++ b/DubUrl.Schema/Builders/IndexColumnBuilder.Interfaces.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema;
+using DubUrl.Schema.Builders;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema.Builders;
+
+/// <summary>
+/// Base interface for all index column builders.
+/// </summary>
+public interface IIndexColumnBuilder
+{
+    /// <summary>
+    /// Builds and returns an Index Column object based on the configured properties.
+    /// </summary>
+    /// <returns>An Index Column object with the configured properties.</returns>
+    IndexColumn Build();
+}
+

--- a/DubUrl.Schema/Builders/IndexColumnBuilder.cs
+++ b/DubUrl.Schema/Builders/IndexColumnBuilder.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema.Builders;
+
+public class IndexColumnBuilder : IIndexColumnBuilder
+{
+    public string Name { get; private set; } = string.Empty;
+
+    public IIndexColumnBuilder WithName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Column name cannot be empty or whitespace.", nameof(name));
+        Name = name;
+        return this;
+    }
+
+    IndexColumn IIndexColumnBuilder.Build()
+    {
+        if (string.IsNullOrWhiteSpace(Name))
+            throw new InvalidOperationException("Column name must be set before building");
+
+        return new IndexColumn(Name);
+    }
+}

--- a/DubUrl.Schema/Builders/IndexColumnCollectionBuilder.cs
+++ b/DubUrl.Schema/Builders/IndexColumnCollectionBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DubUrl.Schema.Builders;
+public class IndexColumnCollectionBuilder : IEnumerable<IIndexColumnBuilder>
+{
+    private List<IIndexColumnBuilder> Columns { get; } = [];
+
+    public IndexColumnCollectionBuilder Add(Func<IndexColumnBuilder, IIndexColumnBuilder> column)
+    {
+        Columns.Add(column(new()));
+        return this;
+    }
+
+    public IEnumerator<IIndexColumnBuilder> GetEnumerator()
+        => Columns.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()
+        => GetEnumerator();
+}

--- a/DubUrl.Schema/Builders/SchemaBuilder.Interfaces.cs
+++ b/DubUrl.Schema/Builders/SchemaBuilder.Interfaces.cs
@@ -8,7 +8,12 @@ namespace DubUrl.Schema.Builders;
 
 public interface ITableCollectionBuilder
 {
-    ISchemaBuilder WithTables(Func<TableCollectionBuilder, TableCollectionBuilder> tables);
+    IIndexCollectionBuilder WithTables(Func<TableCollectionBuilder, TableCollectionBuilder> tables);
+}
+
+public interface IIndexCollectionBuilder : ISchemaBuilder
+{
+    ISchemaBuilder WithIndexes(Func<IndexCollectionBuilder, IndexCollectionBuilder> indexes);
 }
 
 /// <summary>

--- a/DubUrl.Schema/Builders/SchemaBuilder.cs
+++ b/DubUrl.Schema/Builders/SchemaBuilder.cs
@@ -6,23 +6,35 @@ using System.Threading.Tasks;
 
 namespace DubUrl.Schema.Builders;
 
-public class SchemaBuilder : ISchemaBuilder, ITableCollectionBuilder
+public class SchemaBuilder : ISchemaBuilder, ITableCollectionBuilder, IIndexCollectionBuilder
 {
     private TableCollectionBuilder Tables { get; set; } = new();
+    private IndexCollectionBuilder Indexes { get; set; } = new();
 
-    public ISchemaBuilder WithTables(Func<TableCollectionBuilder, TableCollectionBuilder> tables)
+    public IIndexCollectionBuilder WithTables(Func<TableCollectionBuilder, TableCollectionBuilder> tables)
     {
         Tables = tables(Tables);
         return this;
     }
 
-    public Schema Build()
+    ISchemaBuilder IIndexCollectionBuilder.WithIndexes(Func<IndexCollectionBuilder, IndexCollectionBuilder> indexes)
+    {
+        Indexes = indexes(Indexes);
+        return this;
+    }
+
+    Schema ISchemaBuilder.Build()
     {
         var tables = Tables.Select(c => c.Build()).ToArray();
 
         if (tables.GroupBy(c => c.Name).Count() != tables.Length)
             throw new InvalidOperationException("Table names must be unique.");
 
-        return new Schema(tables);
+        var indexes = Indexes.Select(c => c.Build()).ToArray();
+
+        if (indexes.GroupBy(c => c.Name).Count() != indexes.Length)
+            throw new InvalidOperationException("Index names must be unique.");
+
+        return new Schema(tables, indexes);
     }
 }

--- a/DubUrl.Schema/DubUrl.Schema.csproj
+++ b/DubUrl.Schema/DubUrl.Schema.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
+	  <EmbeddedResource Include="Renderers\Templates\CreateIndexes.sql.hbs" />
+	  <EmbeddedResource Include="Renderers\Templates\DropIndexesIfExists.sql.hbs" />
 	  <EmbeddedResource Include="Renderers\Templates\DropTablesIfExists.sql.hbs" />
 	  <EmbeddedResource Include="Renderers\Templates\CreateTables.sql.hbs" />
 	</ItemGroup>

--- a/DubUrl.Schema/Index.cs
+++ b/DubUrl.Schema/Index.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema;
+public class Index
+{
+    public string Name { get; }
+    public string TableName { get; }
+    public OrderedImmutableDictionary<string, IndexColumn> Columns { get; }
+
+    public Index(string name, string tableName, IndexColumn[] columns)
+    {
+        Name = name;
+        TableName = tableName;
+        Columns = OrderedImmutableDictionary<string, IndexColumn>.From(
+                    columns.Select(c => new KeyValuePair<string, IndexColumn>(c.Name, c)));
+    }
+}

--- a/DubUrl.Schema/IndexColumn.cs
+++ b/DubUrl.Schema/IndexColumn.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema;
+public class IndexColumn
+{
+    public string Name { get; }
+    public IndexColumn(string name)
+    {
+        (Name) = (name);
+    }
+
+    
+}

--- a/DubUrl.Schema/Renderers/CreateIndexRenderer.cs
+++ b/DubUrl.Schema/Renderers/CreateIndexRenderer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using Didot.Core;
+using System.Reflection;
+using DubUrl.Querying.TypeMapping;
+using DubUrl.Schema.Templating;
+using DubUrl.Querying.Dialects;
+using DubUrl.Querying.Dialects.Renderers;
+using DubUrl.Querying.Dialects.Functions;
+
+namespace DubUrl.Schema.Renderers;
+public class CreateIndexRenderer : RendererEngine
+{
+    public CreateIndexRenderer(IDialect dialect)
+        : this(CreateHelpers(dialect.Renderer))
+    { }
+    
+    protected CreateIndexRenderer(IDictionary<string, Func<object?, string>> helpers)
+        : base(typeof(CreateIndexRenderer).Assembly, $"{typeof(CreateIndexRenderer).Namespace}.Templates.CreateIndexes.sql.hbs")
+    {
+        foreach (var helper in helpers)
+            AddFormatter(helper.Key, helper.Value);
+    }
+}

--- a/DubUrl.Schema/Renderers/DropIndexesIfExistsRenderer.cs
+++ b/DubUrl.Schema/Renderers/DropIndexesIfExistsRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Didot.Core.TemplateEngines;
+using Didot.Core;
+using System.Reflection;
+using DubUrl.Querying.TypeMapping;
+using DubUrl.Schema.Templating;
+using DubUrl.Querying.Dialects;
+
+namespace DubUrl.Schema.Renderers;
+public class DropIndexesIfExistsRenderer : RendererEngine
+{
+    public DropIndexesIfExistsRenderer(IDialect dialect)
+            : this(CreateHelpers(dialect.Renderer))
+    { }
+
+    protected DropIndexesIfExistsRenderer(IDictionary<string, Func<object?, string>> helpers)
+        : base(typeof(DropIndexesIfExistsRenderer).Assembly, $"{typeof(DropIndexesIfExistsRenderer).Namespace}.Templates.DropIndexesIfExists.sql.hbs")
+    {
+        foreach (var helper in helpers)
+            AddFormatter(helper.Key, helper.Value);
+    }
+}

--- a/DubUrl.Schema/Renderers/IndexColumnViewModel.cs
+++ b/DubUrl.Schema/Renderers/IndexColumnViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema.Renderers;
+public class IndexColumnViewModel
+{
+    public string Name { get; }
+
+    public IndexColumnViewModel(IndexColumn column)
+    {
+        Name = column.Name;
+    }
+}

--- a/DubUrl.Schema/Renderers/IndexViewModel.cs
+++ b/DubUrl.Schema/Renderers/IndexViewModel.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DubUrl.Schema.Constraints;
+
+namespace DubUrl.Schema.Renderers;
+
+public class IndexViewModel
+{
+    public string Name { get; }
+    public string TableName { get; }
+    public IndexColumnViewModel[] Columns { get; }
+
+    public IndexViewModel(Index index)
+    {
+        Name = index.Name;
+        TableName = index.TableName;
+        Columns = index.Columns.Values.Select(c => new IndexColumnViewModel(c)).ToArray();
+    }
+}

--- a/DubUrl.Schema/Renderers/Templates/CreateIndexes.sql.hbs
+++ b/DubUrl.Schema/Renderers/Templates/CreateIndexes.sql.hbs
@@ -1,0 +1,7 @@
+﻿{{#each model.Indexes}}
+CREATE INDEX {{identity Name}} ON {{identity TableName}} (
+{{#each Columns}}
+    {{identity Name}}{{#unless @last}},{{/unless}}
+{{/each}}
+);
+{{/each}}

--- a/DubUrl.Schema/Renderers/Templates/DropIndexesIfExists.sql.hbs
+++ b/DubUrl.Schema/Renderers/Templates/DropIndexesIfExists.sql.hbs
@@ -1,0 +1,3 @@
+﻿{{#each model.Indexes}}
+DROP INDEX IF EXISTS {{identity Name}};
+{{/each}}

--- a/DubUrl.Schema/Schema.cs
+++ b/DubUrl.Schema/Schema.cs
@@ -8,7 +8,13 @@ namespace DubUrl.Schema;
 public class Schema
 {
     public OrderedImmutableDictionary<string, Table> Tables { get; }
+    public OrderedImmutableDictionary<string, Index> Indexes { get; }
+
     public Schema(Table[] tables)
+        : this(tables, [])
+    { }
+
+    public Schema(Table[] tables, Index[] indexes)
     {
         // Check for duplicate table names
         var duplicates = tables.GroupBy(t => t.Name).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
@@ -17,5 +23,13 @@ public class Schema
 
         Tables = OrderedImmutableDictionary<string, Table>.From(
             tables.Select(t => new KeyValuePair<string, Table>(t.Name, t)));
+
+        // Check for duplicate index names
+        var duplicatedIndexes = indexes.GroupBy(t => t.Name).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+        if (duplicatedIndexes.Length > 0)
+            throw new ArgumentException($"Duplicate index names found: {string.Join(", ", duplicates)}", nameof(indexes));
+
+        Indexes = OrderedImmutableDictionary<string, Index>.From(
+            indexes.Select(t => new KeyValuePair<string, Index>(t.Name, t)));
     }
 }

--- a/DubUrl.Schema/Schema.cs
+++ b/DubUrl.Schema/Schema.cs
@@ -27,7 +27,7 @@ public class Schema
         // Check for duplicate index names
         var duplicatedIndexes = indexes.GroupBy(t => t.Name).Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
         if (duplicatedIndexes.Length > 0)
-            throw new ArgumentException($"Duplicate index names found: {string.Join(", ", duplicates)}", nameof(indexes));
+            throw new ArgumentException($"Duplicate index names found: {string.Join(", ", duplicatedIndexes)}", nameof(indexes));
 
         Indexes = OrderedImmutableDictionary<string, Index>.From(
             indexes.Select(t => new KeyValuePair<string, Index>(t.Name, t)));

--- a/DubUrl.Schema/SchemaScriptRenderer.cs
+++ b/DubUrl.Schema/SchemaScriptRenderer.cs
@@ -20,9 +20,13 @@ public class SchemaScriptRenderer
     {
         var templates = new List<RendererEngine>();
         if (options == SchemaCreationOptions.DropIfExists)
+        {
             templates.Add(new DropTablesIfExistsRenderer(dialect));
-
+            templates.Add(new DropIndexesIfExistsRenderer(dialect));
+        }
+            
         templates.Add(new CreateSchemaRenderer(dialect));
+        templates.Add(new CreateIndexRenderer(dialect));
         Templates = [.. templates];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for defining, building, and rendering database indexes within schemas.
  - Introduced new builder interfaces and classes to enable fluent creation of indexes and index columns.
  - Schema rendering now generates SQL for creating and dropping indexes, in addition to tables.
  - Indexes are now included as part of the schema structure.

- **Bug Fixes**
  - None.

- **Tests**
  - Added comprehensive tests for index building, schema building with indexes, and index rendering.

- **Documentation**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->