### PR TITLE
chore: bump System.Data.OleDb from 9.0.5 to 9.0.6

### DIFF
--- a/DubUrl.OleDb/DubUrl.OleDb.csproj
+++ b/DubUrl.OleDb/DubUrl.OleDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.6" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -96,7 +96,7 @@
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.5" />
-    <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.6" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.5" />
-    <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.6" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Net.IBM.Data.Db2" Version="8.0.0.300" Condition="'$(TargetFramework)' == 'net8.0'" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the System.Data.OleDb package to version 9.0.6 across multiple project components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->