### PR TITLE
chore: bump System.Data.Odbc from 9.0.5 to 9.0.6

### DIFF
--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -95,7 +95,7 @@
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
-    <PackageReference Include="System.Data.Odbc" Version="9.0.5" />
+    <PackageReference Include="System.Data.Odbc" Version="9.0.6" />
     <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Npgsql" Version="9.0.3" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Management" Version="9.0.5" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
-    <PackageReference Include="System.Data.Odbc" Version="9.0.5" />
+    <PackageReference Include="System.Data.Odbc" Version="9.0.6" />
     <PackageReference Include="System.Data.OleDb" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the System.Data.Odbc package to version 9.0.6 for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->