### PR TITLE
chore: bump Didot.Core from 0.32.9 to 0.32.17

### DIFF
--- a/DubUrl.Core/DubUrl.csproj
+++ b/DubUrl.Core/DubUrl.csproj
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Didot.Core" Version="0.32.9" />
+    <PackageReference Include="Didot.Core" Version="0.32.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DubUrl.Schema/DubUrl.Schema.csproj
+++ b/DubUrl.Schema/DubUrl.Schema.csproj
@@ -12,7 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Didot.Core" Version="0.32.9" />
+	  <PackageReference Include="Didot.Core" Version="0.32.17" />
 	</ItemGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal package dependencies to a different version. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->