### PR TITLE
chore: bump SQLitePCLRaw.bundle_e_sqlite3 from 2.1.11 to 3.0.1

### DIFF
--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -94,7 +94,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.1" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.8" />
     <PackageReference Include="System.Data.OleDb" Version="9.0.8" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying SQLite engine dependency to the latest major version, improving stability, performance, and compatibility across environments. No behavior changes are expected in normal use.
  * No public APIs were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->