### PR TITLE
chore: bump Microsoft.Data.SqlClient from 6.0.2 to 6.1.1

### DIFF
--- a/DubUrl.BulkCopy.Testing/DubUrl.BulkCopy.Testing.csproj
+++ b/DubUrl.BulkCopy.Testing/DubUrl.BulkCopy.Testing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Npgsql" Version="9.0.3" />

--- a/DubUrl.QA/DubUrl.QA.csproj
+++ b/DubUrl.QA/DubUrl.QA.csproj
@@ -89,7 +89,7 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="DuckDB.NET.Data" Version="1.3.2" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.8" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />

--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.3.2" />
     <PackageReference Include="DuckDB.NET.Data" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.84.1" />
     <PackageReference Include="NReco.PrestoAdo" Version="1.1.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Microsoft.Data.SqlClient dependency to 6.1.1 across QA and testing components.
  * Aligns versions for improved compatibility, stability, and security with newer SQL Server features.
  * No user-facing functionality or public API behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->