### PR TITLE
chore: bump Teradata.Client.Provider from 20.0.5 to 20.0.6

### DIFF
--- a/DubUrl.Testing/DubUrl.Testing.csproj
+++ b/DubUrl.Testing/DubUrl.Testing.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.9.1" />
     <PackageReference Include="MySql.Data" Version="9.4.0" />
     <PackageReference Include="SingleStoreConnector" Version="1.2.0" />
-    <PackageReference Include="Teradata.Client.Provider" Version="20.0.5" />
+    <PackageReference Include="Teradata.Client.Provider" Version="20.0.6" />
     <PackageReference Include="Snowflake.Data" Version="4.7.0" />
     <PackageReference Include="System.Management" Version="9.0.6" />
     <PackageReference Include="Npgsql" Version="9.0.3" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Teradata client dependency to version 20.0.6. This aligns with the vendor release and brings minor stability and compatibility improvements for database connectivity in our test suite. No functional changes to the application are expected and no user action is required. This keeps underlying components current and reduces maintenance risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->